### PR TITLE
Add response to ESCAPE key, as advertised in the documentation.

### DIFF
--- a/form.c
+++ b/form.c
@@ -669,6 +669,8 @@ static struct eventResult formEvent(newtComponent co, struct event ev) {
 		er.result = ER_SWALLOWED;
 		dir = -1;
 		wrap = 1;
+	    } else if (ev.u.key == NEWT_KEY_ESCAPE) {
+		er.result = ER_EXITFORM;
 	    }
 	}
 


### PR DESCRIPTION
I'm not even sure if you accept pull requests, since don't seem to be any.  

I couldn't get the ESCAPE key to exit whiptail forms, so I found the omission and added two lines of code.